### PR TITLE
Switched image to chiseled base for better security and smaller size

### DIFF
--- a/source/TheGrid.Client/Pages/ConnectionManagement/ConnectionList.razor.cs
+++ b/source/TheGrid.Client/Pages/ConnectionManagement/ConnectionList.razor.cs
@@ -11,7 +11,7 @@ namespace TheGrid.Client.Pages.ConnectionManagement
     /// <summary>
     /// Page lists all available connections and controls to manage them.
     /// </summary>
-    public partial class ConnectionList
+    public partial class ConnectionList : ComponentBase
     {
         private IEnumerable<ConnectionListItem> _items = Enumerable.Empty<ConnectionListItem>();
         private int _totalItems;

--- a/source/TheGrid.Server/Dockerfile
+++ b/source/TheGrid.Server/Dockerfile
@@ -1,6 +1,8 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+# This is done to as a workaround for https://github.com/microsoft/DockerTools/issues/409
+# Using the pattern NCarlsonMSFT suggested as a workaround until issue is fixed.
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS debug
 USER app
 WORKDIR /app
 EXPOSE 8080
@@ -9,6 +11,8 @@ EXPOSE 8081
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
+
+# Copy over all the csproj files to perform a restore
 COPY ["TheGrid.Server/TheGrid.Server.csproj", "TheGrid.Server/"]
 COPY ["TheGrid.Client/TheGrid.Client.csproj", "TheGrid.Client/"]
 COPY ["TheGrid.Shared/TheGrid.Shared.csproj", "TheGrid.Shared/"]
@@ -17,7 +21,9 @@ COPY ["TheGrid.Models/TheGrid.Models.csproj", "TheGrid.Models/"]
 COPY ["TheGrid.Services/TheGrid.Services.csproj", "TheGrid.Services/"]
 COPY ["TheGrid.Postgres/TheGrid.Postgres.csproj", "TheGrid.Postgres/"]
 COPY ["TheGrid.Connectors/TheGrid.Connectors.csproj", "TheGrid.Connectors/"]
+
 RUN dotnet restore "./TheGrid.Server/TheGrid.Server.csproj"
+
 COPY . .
 WORKDIR "/src/TheGrid.Server"
 RUN dotnet build "./TheGrid.Server.csproj" -c "$BUILD_CONFIGURATION" -o /app/build
@@ -26,7 +32,8 @@ FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
 RUN dotnet publish "./TheGrid.Server.csproj" -c "$BUILD_CONFIGURATION" -o /app/publish /p:UseAppHost=false
 
-FROM base AS final
+# Use the chiseled image for production use.
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "TheGrid.Server.dll"]


### PR DESCRIPTION
Taking advantage of [chiseled containers](https://devblogs.microsoft.com/dotnet/announcing-dotnet-chiseled-containers/) to run rootless and decrease the image size.

Addresses the sonar finding https://sonarcloud.io/project/security_hotspots?id=PatrickBig_the-grid&hotspots=AY5KXmjC4cOY3zjswkvt