### PR TITLE
Fix tests failing due to InMemoryDatabaseProvider

### DIFF
--- a/source/tests/TheGrid.TestHelpers/DataGenerators/SqliteProvider.cs
+++ b/source/tests/TheGrid.TestHelpers/DataGenerators/SqliteProvider.cs
@@ -1,0 +1,70 @@
+﻿// <copyright file="SqliteProvider.cs" company="BiglerNet">
+// Copyright (c) BiglerNet. All rights reserved.
+// </copyright>
+
+using Microsoft.EntityFrameworkCore;
+using TheGrid.Data;
+
+namespace TheGrid.TestHelpers.DataGenerators
+{
+    /// <summary>
+    /// Creates a Sqlite database with migrations applied.
+    /// </summary>
+    public class SqliteProvider : IDisposable
+    {
+        private readonly string _databasePath;
+        private bool _disposedValue;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SqliteProvider"/> class.
+        /// </summary>
+        public SqliteProvider()
+        {
+            _databasePath = Path.GetTempFileName();
+            var databaseOptions = new DbContextOptionsBuilder<TheGridDbContext>()
+                .UseSqlite("Data Source=" + _databasePath, o => o.MigrationsAssembly("TheGrid.Sqlite"))
+                .EnableDetailedErrors()
+                .EnableSensitiveDataLogging()
+                .Options;
+
+            Db = new TheGridDbContext(databaseOptions);
+
+            Db.Database.Migrate();
+        }
+
+        /// <summary>
+        /// Gets the database context created using the Sqlite provider. This database will already have migrations applied.
+        /// </summary>
+        public TheGridDbContext Db { get; private set; }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes of resources created by this class.
+        /// </summary>
+        /// <param name="disposing">Set to true to dispose of resources.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    Db.Database.EnsureDeleted();
+
+                    if (File.Exists(_databasePath))
+                    {
+                        File.Delete(_databasePath);
+                    }
+                }
+
+                _disposedValue = true;
+            }
+        }
+    }
+}

--- a/source/tests/TheGrid.TestHelpers/InMemoryDatabaseFixture.cs
+++ b/source/tests/TheGrid.TestHelpers/InMemoryDatabaseFixture.cs
@@ -21,9 +21,13 @@ namespace TheGrid.Tests.Shared
         {
             var databaseOptions = new DbContextOptionsBuilder<TheGridDbContext>()
                 .UseInMemoryDatabase("TheGrid")
+                .EnableDetailedErrors()
+                .EnableSensitiveDataLogging()
                 .Options;
 
             Db = new TheGridDbContext(databaseOptions);
+
+            Db.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
         }
 
         /// <summary>

--- a/source/tests/TheGrid.Tests.Services/ConnectorDiscoveryServiceTests.cs
+++ b/source/tests/TheGrid.Tests.Services/ConnectorDiscoveryServiceTests.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using TheGrid.Data;
 using TheGrid.Shared.Models;
+using TheGrid.TestHelpers.DataGenerators;
 using TheGrid.Tests.Shared;
 using Xunit.Abstractions;
 
@@ -15,7 +16,7 @@ namespace TheGrid.Services.Tests
     /// <summary>
     /// Tests for the <see cref="ConnectorDiscoveryService"/>.
     /// </summary>
-    public class ConnectorDiscoveryServiceTests : IClassFixture<InMemoryDatabaseFixture>
+    public class ConnectorDiscoveryServiceTests : IClassFixture<SqliteProvider>
     {
         private readonly TheGridDbContext _db;
         private readonly ILogger<ConnectorDiscoveryService> _logger;
@@ -23,11 +24,11 @@ namespace TheGrid.Services.Tests
         /// <summary>
         /// Initializes a new instance of the <see cref="ConnectorDiscoveryServiceTests"/> class.
         /// </summary>
-        /// <param name="inMemoryDatabaseFixture">In memory database fixture.</param>
+        /// <param name="sqliteProvider">Database fixture.</param>
         /// <param name="testOutputHelper">Test output helper.</param>
-        public ConnectorDiscoveryServiceTests(InMemoryDatabaseFixture inMemoryDatabaseFixture, ITestOutputHelper testOutputHelper)
+        public ConnectorDiscoveryServiceTests(SqliteProvider sqliteProvider, ITestOutputHelper testOutputHelper)
         {
-            _db = inMemoryDatabaseFixture.Db;
+            _db = sqliteProvider.Db;
             _logger = XUnitLogger.CreateLogger<ConnectorDiscoveryService>(testOutputHelper);
         }
 
@@ -64,6 +65,7 @@ namespace TheGrid.Services.Tests
             Assert.Contains(connectors, c => c.Id == "TheGrid.Connectors.PostgreSqlConnector");
 
             // Make sure our test connector is disabled
+            var disabledConnectors = await _db.Connectors.Where(c => c.Disabled).ToListAsync();
             Assert.True(await _db.Connectors.Where(c => c.Id == disableConnector.Id && c.Disabled).AnyAsync());
         }
     }


### PR DESCRIPTION
The way the in memory database provider is working for EF we were getting test failures due to how entities were being tracked.

Switching some of the troublesome tests to using a Sqlite provider instead to solve the problem.