### PR TITLE
Adding code coverage for controllers

### DIFF
--- a/source/TheGrid.Server/Controllers/ConnectionsController.cs
+++ b/source/TheGrid.Server/Controllers/ConnectionsController.cs
@@ -43,7 +43,7 @@ namespace TheGrid.Server.Controllers
         [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(typeof(CreateConnectionResponse), StatusCodes.Status201Created)]
         [HttpPost]
-        public async Task<ActionResult<CreateConnectionResponse>> Post([FromBody] CreateConnectionRequest request, CancellationToken cancellationToken = default)
+        public async Task<ActionResult> Post([FromBody] CreateConnectionRequest request, CancellationToken cancellationToken = default)
         {
             if (!await _db.Organizations.AnyAsync(d => d.Id == request.OrganizationId, cancellationToken))
             {
@@ -71,8 +71,10 @@ namespace TheGrid.Server.Controllers
         /// <param name="connectionId">The ID of the connection to fetch.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Information about the connection.</returns>
+        [ProducesResponseType(typeof(Connection), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
         [HttpGet("{connectionId:int}")]
-        public async Task<ActionResult<Connection>> Get([FromRoute] int connectionId, CancellationToken cancellationToken = default)
+        public async Task<ActionResult> Get([FromRoute] int connectionId, CancellationToken cancellationToken = default)
         {
             var connection = await _db.Connections.FirstOrDefaultAsync(d => d.Id == connectionId, cancellationToken);
 

--- a/source/tests/TheGrid.TestHelpers/Fixtures/OrganizationWithConnection.cs
+++ b/source/tests/TheGrid.TestHelpers/Fixtures/OrganizationWithConnection.cs
@@ -28,7 +28,7 @@ namespace TheGrid.TestHelpers.Fixtures
                         Name = "Test Connection",
                         Connector = new TheGrid.Shared.Models.Connector
                         {
-                            Id = "TheGrid.Connectors.TestConnector",
+                            Id = GetTestConnectorId(),
                             Name = "Fake Database Connection",
                             SupportsConnectionTest = false,
                             SupportsSchemaDiscovery = false,
@@ -41,7 +41,7 @@ namespace TheGrid.TestHelpers.Fixtures
 
             Db.SaveChanges();
 
-            ConnectionId = organization.Connections.First().Id;
+            ConnectionId = organization.Connections[0].Id;
         }
 
         /// <summary>
@@ -53,5 +53,11 @@ namespace TheGrid.TestHelpers.Fixtures
         /// Gets the ID of the default connection setup using the test connector.
         /// </summary>
         public int ConnectionId { get; private set; }
+
+        /// <summary>
+        /// Gest the test connector ID.
+        /// </summary>
+        /// <returns>The test connector ID.</returns>
+        public string GetTestConnectorId() => "TheGrid.Connectors.TestConnector";
     }
 }

--- a/source/tests/TheGrid.TestHelpers/Fixtures/OrganizationWithConnection.cs
+++ b/source/tests/TheGrid.TestHelpers/Fixtures/OrganizationWithConnection.cs
@@ -58,6 +58,6 @@ namespace TheGrid.TestHelpers.Fixtures
         /// Gest the test connector ID.
         /// </summary>
         /// <returns>The test connector ID.</returns>
-        public string GetTestConnectorId() => "TheGrid.Connectors.TestConnector";
+        public static string GetTestConnectorId() => "TheGrid.Connectors.TestConnector";
     }
 }

--- a/source/tests/TheGrid.Tests.Server/Controllers/ConnectionsControllerTests.cs
+++ b/source/tests/TheGrid.Tests.Server/Controllers/ConnectionsControllerTests.cs
@@ -3,11 +3,6 @@
 // </copyright>
 
 using Microsoft.AspNetCore.Mvc;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using TheGrid.Models;
 using TheGrid.Server.Controllers;
 using TheGrid.Shared.Models;
@@ -22,6 +17,10 @@ namespace TheGrid.Tests.Server.Controllers
     {
         private readonly OrganizationWithConnection _fixture;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConnectionsControllerTests"/> class.
+        /// </summary>
+        /// <param name="fixture">Testing fixture.</param>
         public ConnectionsControllerTests(OrganizationWithConnection fixture)
         {
             _fixture = fixture;
@@ -40,7 +39,7 @@ namespace TheGrid.Tests.Server.Controllers
             var request = new CreateConnectionRequest
             {
                 Name = "Test connection",
-                ConnectorId = _fixture.GetTestConnectorId(),
+                ConnectorId = OrganizationWithConnection.GetTestConnectorId(),
                 OrganizationId = _fixture.OrganizationId,
             };
 
@@ -101,7 +100,7 @@ namespace TheGrid.Tests.Server.Controllers
             var request = new CreateConnectionRequest
             {
                 Name = "Test connection",
-                ConnectorId = _fixture.GetTestConnectorId(),
+                ConnectorId = OrganizationWithConnection.GetTestConnectorId(),
                 OrganizationId = "invalid_org",
             };
 

--- a/source/tests/TheGrid.Tests.Server/Controllers/ConnectionsControllerTests.cs
+++ b/source/tests/TheGrid.Tests.Server/Controllers/ConnectionsControllerTests.cs
@@ -1,0 +1,188 @@
+﻿// <copyright file="ConnectionsControllerTests.cs" company="BiglerNet">
+// Copyright (c) BiglerNet. All rights reserved.
+// </copyright>
+
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TheGrid.Models;
+using TheGrid.Server.Controllers;
+using TheGrid.Shared.Models;
+using TheGrid.TestHelpers.Fixtures;
+
+namespace TheGrid.Tests.Server.Controllers
+{
+    /// <summary>
+    /// Tests for the <see cref="ConnectionsController"/> class.
+    /// </summary>
+    public class ConnectionsControllerTests : IClassFixture<OrganizationWithConnection>
+    {
+        private readonly OrganizationWithConnection _fixture;
+
+        public ConnectionsControllerTests(OrganizationWithConnection fixture)
+        {
+            _fixture = fixture;
+        }
+
+        /// <summary>
+        /// Tests the ability to create a new connection.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task CreateConnection_Success_Test()
+        {
+            // Arrange
+            var controller = new ConnectionsController(_fixture.Db);
+
+            var request = new CreateConnectionRequest
+            {
+                Name = "Test connection",
+                ConnectorId = _fixture.GetTestConnectorId(),
+                OrganizationId = _fixture.OrganizationId,
+            };
+
+            // Act
+            var actionResult = await controller.Post(request);
+
+            // Assert
+            Assert.IsType<CreatedAtActionResult>(actionResult);
+            var result = actionResult as CreatedAtActionResult;
+            Assert.NotNull(result);
+            Assert.IsType<CreateConnectionResponse>(result.Value);
+            var response = result.Value as CreateConnectionResponse;
+            Assert.NotNull(response);
+        }
+
+        /// <summary>
+        /// Tests that a problem is returned if the connector id is invalid.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task CreateConnection_Invalid_ConnectorId_Test()
+        {
+            // Arrange
+            var controller = new ConnectionsController(_fixture.Db);
+
+            var request = new CreateConnectionRequest
+            {
+                Name = "Test connection",
+                ConnectorId = "invalid_connector_id",
+                OrganizationId = _fixture.OrganizationId,
+            };
+
+            // Act
+            var actionResult = await controller.Post(request);
+
+            // Assert
+            Assert.IsType<ObjectResult>(actionResult);
+            var result = actionResult as ObjectResult;
+            Assert.NotNull(result);
+            Assert.IsType<ValidationProblemDetails>(result.Value);
+            var response = result.Value as ValidationProblemDetails;
+            Assert.NotNull(response);
+
+            // Make sure we have a validation error with the connector ID as an affected property
+            Assert.True(response.Errors.ContainsKey(nameof(CreateConnectionRequest.ConnectorId)));
+        }
+
+        /// <summary>
+        /// Tests that a problem is returned if the organization is invalid.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task CreateConnection_Invalid_Organization_Test()
+        {
+            // Arrange
+            var controller = new ConnectionsController(_fixture.Db);
+
+            var request = new CreateConnectionRequest
+            {
+                Name = "Test connection",
+                ConnectorId = _fixture.GetTestConnectorId(),
+                OrganizationId = "invalid_org",
+            };
+
+            // Act
+            var actionResult = await controller.Post(request);
+
+            // Assert
+            Assert.IsType<ObjectResult>(actionResult);
+            var result = actionResult as ObjectResult;
+            Assert.NotNull(result);
+            Assert.IsType<ValidationProblemDetails>(result.Value);
+            var response = result.Value as ValidationProblemDetails;
+            Assert.NotNull(response);
+
+            // Make sure we have a validation error with the connector ID as an affected property
+            Assert.True(response.Errors.ContainsKey(nameof(CreateConnectionRequest.OrganizationId)));
+        }
+
+        /// <summary>
+        /// Tests the ability to get a connection.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task GetConnection_Ok_Test()
+        {
+            // Arrange
+            var controller = new ConnectionsController(_fixture.Db);
+            var connectionId = _fixture.ConnectionId;
+
+            // Act
+            var actionResult = await controller.Get(connectionId);
+
+            // Assert
+            Assert.IsType<OkObjectResult>(actionResult);
+            var result = actionResult as OkObjectResult;
+            Assert.NotNull(result);
+            Assert.IsType<Connection>(result.Value);
+            var response = result.Value as Connection;
+            Assert.NotNull(response);
+            Assert.NotNull(response.Name);
+        }
+
+        /// <summary>
+        /// Tests that when trying to fetch a connection that does not exist that a <see cref="NotFoundResult"/> is returned.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task GetConnection_NotFound_Test()
+        {
+            // Arrange
+            var controller = new ConnectionsController(_fixture.Db);
+
+            // Act
+            var actionResult = await controller.Get(-5);
+
+            // Assert
+            Assert.NotNull(actionResult);
+            Assert.IsType<NotFoundResult>(actionResult);
+        }
+
+        /// <summary>
+        /// Tests the ability to get a list of connections.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task GetConnectionList_Ok_Test()
+        {
+            // Arrange
+            var controller = new ConnectionsController(_fixture.Db);
+
+            // Act
+            var actionResult = await controller.GetList(_fixture.OrganizationId);
+
+            // Assert
+            Assert.IsType<OkObjectResult>(actionResult);
+            var result = actionResult as OkObjectResult;
+            Assert.NotNull(result);
+            Assert.IsType<PaginatedResult<ConnectionListItem>>(result.Value);
+            var response = result.Value as PaginatedResult<ConnectionListItem>;
+            Assert.NotNull(response);
+            Assert.NotEmpty(response.Items);
+        }
+    }
+}


### PR DESCRIPTION
This adds some test coverage for controllers in TheGrid.Server.Controllers

* Added tests for the ConnectionsController
* Added response type documentation to the ConnectionsController Made return types consistent for methods in ConnectionsController